### PR TITLE
Fix Kamailio startup command

### DIFF
--- a/live-demo/k8s/02-kamailio.yaml
+++ b/live-demo/k8s/02-kamailio.yaml
@@ -54,8 +54,7 @@ spec:
               value: gcp
         - name: dispatchers
           image: cycoresystems/dispatchers
-          command:
-            - /app
+          args:
             - "-set"
             - voip:asterisk=1:5080
           volumeMounts:


### PR DESCRIPTION
error on container startup
`Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/app": stat /app: no such file or directory: unknown`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/asterisk-k8s-demo/25)
<!-- Reviewable:end -->
